### PR TITLE
Add hover method

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+1.3.1 (2019-07-08):
+
+    * Add method hover_over_button to the NavigationTestMixin to
+      perform hover actions.
+
 1.3.0 (2018-04-17):
 
     * Add support for asserting string should or should not appear

--- a/selenium_testcase/testcases/navigation.py
+++ b/selenium_testcase/testcases/navigation.py
@@ -7,6 +7,7 @@ from urlparse import urljoin
 from django.urls import reverse
 from selenium.webdriver.support.ui import Select
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.action_chains import ActionChains
 
 from .utils import wait_for
 
@@ -61,6 +62,12 @@ class NavigationTestMixin:
         """ Select a button or link with the given name.  """
         button = self.get_button(value, *args, **kwargs)
         button.click()
+
+    def hover_over_button(self, value, *args, **kwargs):
+        """ Hover over a button or link with the given name. """
+        button = self.get_button(value, *args, **kwargs)
+        hover = ActionChains(self.browser).move_to_element(button)
+        hover.perform()
 
     @wait_for
     def at_page(self, url, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 # setup the project
 setup(
     name="django-selenium-testcase",
-    version="1.3.0",
+    version="1.3.1",
     author="Nimbis Services, Inc.",
     author_email="info@nimbisservices.com",
     description="Selenium helper methods for Django live server testing.",


### PR DESCRIPTION
Add method to NavigationTestMixin to hover over a button or link.

The hover_over_button method is added to perform hover actions
in the browser. These actions are needed to test UI elements such
as dropdown menus, which only appear when hovering over a button
or link.

This method was added after observing the 
test_switching_project_views_with_project_dropdown test was failing
on Firefox. That test initially tried to click on the dropdown
link to render the menu items. That approach worked when testing
on Chrome, but failed on Firefox.

Using the hover_over_button method should work for both browsers
and performs the correct actions needed for that test.